### PR TITLE
Docker in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.DS_Store
+.git
+.gitignore
+Dockerfile
+README.md
+.cache
+*/*/*.py[cod]
+*/*.py[cod]
+*.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM gliderlabs/alpine:3.3
+
+WORKDIR /usr/local/navitia
+
+RUN apk add --update \
+    alpine-sdk \
+    python \
+    python-dev \
+    py-pip \
+    docker \
+  && rm -rf /var/cache/apk/*
+
+# Install openrc - see: https://github.com/gliderlabs/docker-alpine/issues/42
+RUN apk update && apk add openrc &&\
+# Tell openrc its running inside a container, till now that has meant LXC
+    sed -i 's/#rc_sys=""/rc_sys="lxc"/g' /etc/rc.conf &&\
+# Tell openrc loopback and net are already there, since docker handles the networking
+    echo 'rc_provide="loopback net"' >> /etc/rc.conf &&\
+# no need for loggers
+    sed -i 's/^#\(rc_logger="YES"\)$/\1/' /etc/rc.conf &&\
+# can't get ttys unless you run the container in privileged mode
+    sed -i '/tty/d' /etc/inittab &&\
+# can't set hostname since docker sets it
+    sed -i 's/hostname $opts/# hostname $opts/g' /etc/init.d/hostname &&\
+# can't mount tmpfs since not privileged
+    sed -i 's/mount -t tmpfs/# mount -t tmpfs/g' /lib/rc/sh/init.sh &&\
+# can't do cgroups
+    sed -i 's/cgroup_add_service /# cgroup_add_service /g' /lib/rc/sh/openrc-run.sh
+
+COPY ./requirements.txt /usr/local/navitia/docker_navitia/requirements.txt
+RUN pip install -r /usr/local/navitia/docker_navitia/requirements.txt
+
+RUN git clone https://github.com/CanalTP/fabric_navitia.git /usr/local/navitia/fabric_navitia
+RUN pip install -r /usr/local/navitia/fabric_navitia/requirements.txt
+
+ENV PYTHONPATH /usr/local/navitia:/usr/local/navitia/docker_navitia:/usr/local/navitia/fabric_navitia:/usr/bin/python
+
+# RUN echo -e '#!/bin/bash\n/sbin/init && service docker start' > /usr/local/navitia/entrypoint.sh && chmod +x /usr/local/navitia/entrypoint.sh
+
+COPY . /usr/local/navitia/docker_navitia
+
+WORKDIR /usr/local/navitia/docker_navitia
+
+ENTRYPOINT ["/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ Then, the resulting Docker image can be created via:
 
 A similar process is available for the composed platform, simply replace *test_deploy_simple* with *test_deploy_composed*.
 
+Since this build process requires to be run in a Linux environment, if you're on a different platform you can use Docker to build Docker :)
+
+So first build the image:
+`docker build -t navitia-builder .`
+
+Then run it:
+`docker run --name navitia-builder-container -d --privileged navitia-builder`
+
+Then shell into the machine:
+`docker exec -it navitia-builder-container /bin/ash`
+
+Then start the Docker daemon:
+`service docker start`
+
+So now you can build:
+`py.test -s -k test_deploy_simple --build`
+
+When finished, you can remove it:
+`docker rm -f navitia-builder-container`
+
 ## Play with Navitia images
 You can check existing Navitia images on docker hub, type `docker search navitia`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ docker-compose==1.2.0
 docker-py==1.1.0
 pytest==2.7.1
 requests==2.5.3
+fabric==1.10.2
+jinja2==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest==2.7.1
 requests==2.5.3
 fabric==1.10.2
 jinja2==2.8
+nose==1.3.7


### PR DESCRIPTION
Since it seems the build script assumes it's running under Linux, I created a Dockerfile which creates a container inside which it's possible to build the Navitia Docker images. This way not only that you can build the images on any system (OS X / Windows / etc), but you also don't need to worry about the Python dependencies.

Note: it's not completely finished yet as I haven't figured out what to do with the image once it's built, but wanted to share early.